### PR TITLE
Implement mobile hamburger menu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -266,6 +266,61 @@ nav a::after {
     top: 9px;
 }
 
+/* Mobile navigation styles */
+@media (max-width: 768px) {
+    .hamburger {
+        display: block;
+    }
+
+    nav.mobile-nav {
+        position: fixed;
+        top: 0;
+        right: 0;
+        width: 80%;
+        max-width: 300px;
+        height: 100vh;
+        background: rgba(0, 0, 0, 0.95);
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 999;
+        padding-top: 80px;
+    }
+
+    nav.mobile-nav ul {
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    nav.mobile-nav.active {
+        transform: translateX(0);
+    }
+
+    body.menu-open {
+        overflow: hidden;
+    }
+
+    .nav-overlay {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 998;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+    }
+
+    body.menu-open .nav-overlay {
+        display: block;
+        opacity: 1;
+    }
+}
+
 /* Mobile styles */
 @media (max-width: 768px) {
     /* Hide desktop nav */
@@ -872,8 +927,4 @@ section {
     }
 }
 
-.nav-overlay {
-    display: none !important;
-    background: none !important;
-}
 

--- a/index.html
+++ b/index.html
@@ -28,6 +28,11 @@
                 <li><a href="#eker-design">Eker Design</a></li>
             </ul>
         </nav>
+        <button class="hamburger" aria-label="Toggle navigation">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
     </div>
 </header>
 

--- a/js/script.js
+++ b/js/script.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const hamburger = document.querySelector('.hamburger');
     const nav = document.querySelector('nav');
     const navLinks = document.querySelectorAll('nav a');
+    const overlay = document.querySelector('.nav-overlay');
     let isMenuOpen = false;
 
     function toggleMenu() {
@@ -9,6 +10,9 @@ document.addEventListener('DOMContentLoaded', function() {
         hamburger.classList.toggle('active');
         nav.classList.toggle('active');
         document.body.classList.toggle('menu-open');
+        if (overlay) {
+            overlay.classList.toggle('active');
+        }
     }
 
     // Toggle menu on hamburger click
@@ -39,12 +43,20 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
-    // Close menu when clicking outside
+    // Close menu when clicking outside or on overlay
     document.addEventListener('click', (e) => {
         if (isMenuOpen && !nav.contains(e.target) && !hamburger.contains(e.target)) {
             toggleMenu();
         }
     });
+
+    if (overlay) {
+        overlay.addEventListener('click', () => {
+            if (isMenuOpen) {
+                toggleMenu();
+            }
+        });
+    }
 
     // Close menu on scroll
     document.addEventListener('scroll', () => {


### PR DESCRIPTION
## Summary
- add hamburger toggle button in header
- style mobile navigation overlay menu
- hide body scroll when menu is open
- toggle overlay and nav via script

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842968d83448332a5c502cc2982fe5d